### PR TITLE
ignore nonexistent temp file

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ default: clean
 	echo "##END COINHIVE">>hostfile;
 install:
 	cp /etc/hosts hosts;
-	-rm .temp
+	-rm -f .temp
 	sed '/##COINHIVE DOMAINS/,/##END COINHIVE/d' hosts >> .temp
 	cat hostfile >> .temp
 	mv .temp hosts


### PR DESCRIPTION
When `.temp` doesn't exist, `make` completes successfully but also
produces the following output that is potentially confusing.

```
rm: cannot remove '.temp': No such file or directory
makefile:6: recipe for target 'install' failed
make: [install] Error 1 (ignored)
```

Ask `rm` not to prompt in this case.